### PR TITLE
Add webapp deploy steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 `kubectl apply -f redis`
 
 * Deploy web application
-`kubectl apply -f webapp/deploy/app.deployment.yml`
-`kubectl apply -f webapp/deploy/app.service.yml`
+    * `kubectl apply -f webapp/deploy/app.configmap.yml`
+    * `kubectl apply -f webapp/deploy/app.service.yml`
+    * `kubectl apply -f webapp/deploy/app.deployment.yml`
+    * `kubectl apply -f webapp/deploy/app.service.yml`
 
 * Manually scale webapp
 `kubectl scale deployment webapp --replicas=3`


### PR DESCRIPTION
Couldn't get past ContainerCreating; kubectl describe pod webapp-68d66c6cdf-962cb showed "secrets "webapp" not found" and  "Error: configmaps "webapp" not found" in turn.  Worked great after applying all the yaml in the webapp directory