### PR TITLE
fixing typo in first command and markdown

### DIFF
--- a/complete/README.md
+++ b/complete/README.md
@@ -3,7 +3,7 @@
 ## Complete Workshop Walkthrough
 
 1. Create namespace
-    * `kubeclt apply -f namespace.yml
+    * `kubectl apply -f namespace.yml`
 1. Deploy redis:
     * `kubectl apply -f 01_redis/`
     * `kubectl get deployments`


### PR DESCRIPTION
Change kubeclt to kubectl and adding the missing "`" so be able to simply copy and paste the command again. :) 