### PR TITLE
Add an Ingress supporting Kube 1.18.0 and earlier

### DIFF
--- a/complete/03_ingress/app.ingress-v1.18.yaml
+++ b/complete/03_ingress/app.ingress-v1.18.yaml
@@ -1,0 +1,25 @@
+# This Ingress is for Kube versions 1.18.0 and earlier.
+#
+# You may need to change the ingress class below,
+# to match the Nginx Ingress configuration.
+#
+# Access this INgress by specifying the HOST header.
+# Replace ${load_balancer_ip} with the IP of an Ingress Controller LB.
+# curl --header 'HOST: test.domain.com' ${load_balancer_ip}/
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: webapp
+  namespace: k8s-workshop
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: test.domain.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: webapp
+          servicePort: 80

--- a/complete/README.md
+++ b/complete/README.md
@@ -74,6 +74,6 @@ This section allows us to load test the web app and see the cluster responding b
 * The number of pods should scale up to meet the new demand `kubectl get deployment, po -n k8s-workshop`
 
 ### Optional Ingress (Separate Controller Required)
-The `03_ingress` sub-directory contains an optional Ingress definition. The `kubernetes.io/ingress.class` annotation may need to be changed to match that of your Ingress Controller.
+The `03_ingress` sub-directory contains an optional Ingress definition. The `kubernetes.io/ingress.class` annotation may need to be changed to match that of your Ingress Controller. There is a second `v1.18` yaml file for Kubernetes versions v1.18.0 and earlier, which do not support the `networking.k8s.io/v1` APIVersion of Ingress.
 
 Note that an Ingress Controller must be installed for Ingress resources to function. See the [Ingress Nginx installation instructions](https://kubernetes.github.io/ingress-nginx/deploy/) for more information.


### PR DESCRIPTION
Kube 1.18 and earlier, such as currently found in new GKE installations,
do not support `networking.k8s.io/v1` Ingresses. This file provides the
older Ingress.